### PR TITLE
Clarify the keyboard focus warning

### DIFF
--- a/revenge.css
+++ b/revenge.css
@@ -179,8 +179,8 @@ a[class*="button"]:not([role="button"]):after {
    content: 'If you are going to make it look like a button, make it a button, dammit!' !important;
 }
 
-.button:not(a):not(button):not(input):after, 
-.btn:not(a):not(button):not(input):after {
+.button:not(a):not(button):not(input):not([tabindex]):after, 
+.btn:not(a):not(button):not(input):not([tabindex]):after {
 	content: 'You are not using a standard focusable element for your "button". Can keyboard users focus on it?' !important;
 }
 


### PR DESCRIPTION
The warning is confusing if the developr has set the `tabindex` properly.
I strongly agree on using proper HTML elements, but we still have [another warning](https://github.com/denis-sokolov/REVENGE.CSS/blob/4473d1227a365ed180982937cddb1fd2cf3ed268/revenge.css#L179) that is more specific and clear to developers.
