### PR TITLE
Decrepidos patch 1

### DIFF
--- a/revenge.css
+++ b/revenge.css
@@ -231,8 +231,11 @@ button.disabled:not([disabled]):not([readonly])::after {
 acronym::after, applet::after, basefont::after, big::after, center::after, dir::after, 
 font::after, frame::after, frameset::after, isindex::after, listing::after, menu::after, multicol::after, 
 plaintext::after, strike::after, u::after, xmp::after, bgsound::after, blink::after, comment::after, 
-embed::after, marquee::after, nobr::after, noembed::after, wbr::after {
+embed::after, marquee::after, nobr::after, noembed::after, wbr::after, :not(span.MathJax .math) {
 	content: 'This element is deprecated, non-standard or obsolete.' !important;
+}
+span.MathJax .math::after {
+	content: 'This is a MathJax symbol.' !important;
 }
 
 /**

--- a/revenge.css
+++ b/revenge.css
@@ -240,7 +240,7 @@ embed::after, marquee::after, nobr::after, noembed::after, wbr::after {
 ----------------------------------------------------------------------
 */
 
-*:empty:not(script):not(input):not(br):not(img):not(link):not(hr):not(embed):not(area):not(command):not(col):not(param):not(source):not(track):not(wbr):not(base):not(keygen)::after {
+*:empty:not(script):not(input):not(br):not(img):not(link):not(hr):not(embed):not(area):not(command):not(col):not(param):not(source):not(track):not(wbr):not(base):not(keygen):not(span.fa)::after {
 	content: 'This element is empty. Why?' !important;
 }
 
@@ -260,14 +260,25 @@ aside > article:first-child::after,
 aside > section:first-child::after {
 	content: 'Sectioning elems are not arbitrary wrappers. Use <div>s here.' !important;
 }
+/****
+Removed as <footer> conveys contentInfo natively and
+****/
 
 body > header:not([role="banner"])::after, body > div > header:not([role="banner"])::after {
 	content: 'Use role="banner" on this header element.' !important;
 }
-
+/*
 body > footer:not([role="contentinfo"])::after, body > div > footer:not([role="contentinfo"])::after {
 	content: 'Use role="contentinfo" on this footer element.' !important;
 }
+*/
+/****
+Removed as <footer> conveys contentInfo natively and updated if using non native footer element using either class footer or id footer add role contentInfo
+****/
+body > footer#footer:not([role="contentinfo"])::after, body > div > footer.footer:not([role="contentinfo"])::after {
+	content: 'Use role="contentinfo" on this footer element or use native HTML5 <footer>.' !important;
+}
+
 
 section [role="banner"]::after, section [role="contentinfo"]::after, 
 article [role="banner"]::after, article [role="contentinfo"]::after, 

--- a/revenge.css
+++ b/revenge.css
@@ -251,7 +251,7 @@ Icons used for pure decoration or visual styling
 If you're using an icon to add some extra decoration or branding, it does not need to be announced to users as they are navigating your site or app aurally. Additionally, if you're using an icon to visually re-emphasize or add styling to content already present in your HTML, it does not need to be repeated to an assistive technology-using user. You can make sure this is not read by adding the aria-hidden="true" to your Font Awesome markup.
 http://fontawesome.io/accessibility/
 ****************/
-.fa:not([aria-hidden="true"])::after {
+:not(i.fa[aria-hidden="true"])::after, :not(span.fa[aria-hidden="true"])::after {
     content: 'Use aria-hidden="true on icons.' !important;
 }
 

--- a/revenge.css
+++ b/revenge.css
@@ -140,7 +140,8 @@ li.disabled > a[href]:not([tabindex="-1"])::after,
 li.disabled > button:not([disabled])::after, 
 a.disabled[href]:not([tabindex="-1"])::after,
 button.disabled:not([disabled])::after, 
-[data-toggle="dropdown"]:not([aria-haspopup])::after
+[data-toggle="dropdown"]:not([aria-haspopup])::after,
+span.MathJax .math::after
 {
    display: inline-block !important;
    background: #dc143c !important;

--- a/revenge.css
+++ b/revenge.css
@@ -251,7 +251,7 @@ Icons used for pure decoration or visual styling
 If you're using an icon to add some extra decoration or branding, it does not need to be announced to users as they are navigating your site or app aurally. Additionally, if you're using an icon to visually re-emphasize or add styling to content already present in your HTML, it does not need to be repeated to an assistive technology-using user. You can make sure this is not read by adding the aria-hidden="true" to your Font Awesome markup.
 http://fontawesome.io/accessibility/
 ****************/
-:not(.fa[aria-hidden="true"])::after {
+:not(.fa *[aria-hidden="true"])::after {
     content: 'Use aria-hidden="true on icons.' !important;
 }
 

--- a/revenge.css
+++ b/revenge.css
@@ -140,9 +140,7 @@ li.disabled > a[href]:not([tabindex="-1"])::after,
 li.disabled > button:not([disabled])::after, 
 a.disabled[href]:not([tabindex="-1"])::after,
 button.disabled:not([disabled])::after, 
-[data-toggle="dropdown"]:not([aria-haspopup])::after,
-span.MathJax .math::after,
-.sr-only:after
+[data-toggle="dropdown"]:not([aria-haspopup])::after
 {
    display: inline-block !important;
    background: #dc143c !important;
@@ -236,9 +234,6 @@ plaintext::after, strike::after, u::after, xmp::after, bgsound::after, blink::af
 embed::after, marquee::after, nobr::after, noembed::after, wbr::after, :not(span.MathJax .math)::after {
 	content: 'This element is deprecated, non-standard or obsolete.' !important;
 }
-span.MathJax .math::after {
-	content: 'This is a MathJax symbol.' !important;
-}
 
 /**
 * Empty elements
@@ -252,10 +247,8 @@ Added not:span.fa and i.fa to exclude icons hooks.
 }
 /**
 Icons used for pure decoration or visual styling
-
-If you're using an icon to add some extra decoration or branding, it does not need to be announced to users as they are navigating your site or app aurally. Additionally, if you're using an icon to visually re-emphasize or add styling to content already present in your HTML, it does not need to be repeated to an assistive technology-using user. You can make sure this is not read by adding the aria-hidden="true" to your Font Awesome markup.
-http://fontawesome.io/accessibility/
-****************/
+----------------------------------------------------------------------
+*/
 i.fa:not([aria-hidden="true"])::after, span.fa:not([aria-hidden="true"])::after {
     content: 'Use aria-hidden="true on icons.' !important;
 }
@@ -280,18 +273,12 @@ aside > section:first-child::after {
 
 /****
 Removed as <footer> requires role=contentInfo and <header> requires role=banner as these are already conveyed natively. W3C validator generates a warning if used.
-****/
-/*
-body > div#footer:not([role="contentinfo"])::after, body > div.footer:not([role="contentinfo"])::after {
-	content: 'Use role="contentinfo" on this footer element or use native HTML5 <footer>.' !important;
-}
-body > div#header:not([role="banner"])::after, body > div.header:not([role="banner"])::after, body > div.banner:not([role="banner"])::after, body > div#banner:not([role="banner"])::after {
-	content: 'Use role="banner" on this header element or use native <header>.' !important;
-}
+----------------------------------------------------------------------
 */
 
 /***
-if div has class or ID of header. Considering if .banner #banner should be included
+if div has class or ID of header.
+----------------------------------------------------------------------
 */
 div#header:not([role="banner"])::after, div.header:not([role="banner"])::after {
 	content: 'Use role="banner" on this header element or use native <header>.' !important;
@@ -409,8 +396,4 @@ button.disabled:not([disabled])::after {
 
 [data-toggle="dropdown"]:not([aria-haspopup])::after {
 	content: 'Indicate the hidden menu with aria-haspopup' !important;
-}
-
-.sr-only:after{
-   content: 'Off-screen text for screen reader users. Is this text necessary?' !important; 
 }

--- a/revenge.css
+++ b/revenge.css
@@ -260,25 +260,26 @@ aside > article:first-child::after,
 aside > section:first-child::after {
 	content: 'Sectioning elems are not arbitrary wrappers. Use <div>s here.' !important;
 }
-/****
-Removed as <footer> conveys contentInfo natively and
-****/
 
+/*
 body > header:not([role="banner"])::after, body > div > header:not([role="banner"])::after {
 	content: 'Use role="banner" on this header element.' !important;
 }
+*/
 /*
 body > footer:not([role="contentinfo"])::after, body > div > footer:not([role="contentinfo"])::after {
 	content: 'Use role="contentinfo" on this footer element.' !important;
 }
 */
 /****
-Removed as <footer> conveys contentInfo natively and updated if using non native footer element using either class footer or id footer add role contentInfo
+Removed as <footer> conveys contentInfo natively and updated if using non native footer element using either class footer or id footer add role contentInfo. Same for header
 ****/
 body > footer#footer:not([role="contentinfo"])::after, body > div > footer.footer:not([role="contentinfo"])::after {
 	content: 'Use role="contentinfo" on this footer element or use native HTML5 <footer>.' !important;
 }
-
+body > div#header:not([role="banner"])::after, body > div.header:not([role="banner"])::after, body > div.banner:not([role="banner"])::after, body > div#banner:not([role="banner"])::after {
+	content: 'Use role="banner" on this header element or use native <header>.' !important;
+}
 
 section [role="banner"]::after, section [role="contentinfo"]::after, 
 article [role="banner"]::after, article [role="contentinfo"]::after, 

--- a/revenge.css
+++ b/revenge.css
@@ -251,7 +251,7 @@ Icons used for pure decoration or visual styling
 If you're using an icon to add some extra decoration or branding, it does not need to be announced to users as they are navigating your site or app aurally. Additionally, if you're using an icon to visually re-emphasize or add styling to content already present in your HTML, it does not need to be repeated to an assistive technology-using user. You can make sure this is not read by adding the aria-hidden="true" to your Font Awesome markup.
 http://fontawesome.io/accessibility/
 ****************/
-.fa:not([aria-hidden="true"])::after {
+:not(.fa[aria-hidden="true"])::after {
     content: 'Use aria-hidden="true on icons.' !important;
 }
 

--- a/revenge.css
+++ b/revenge.css
@@ -231,7 +231,7 @@ button.disabled:not([disabled]):not([readonly])::after {
 acronym::after, applet::after, basefont::after, big::after, center::after, dir::after, 
 font::after, frame::after, frameset::after, isindex::after, listing::after, menu::after, multicol::after, 
 plaintext::after, strike::after, u::after, xmp::after, bgsound::after, blink::after, comment::after, 
-embed::after, marquee::after, nobr::after, noembed::after, wbr::after, :not(span.MathJax .math) {
+embed::after, marquee::after, nobr::after, noembed::after, wbr::after, .MathJax::after {
 	content: 'This element is deprecated, non-standard or obsolete.' !important;
 }
 span.MathJax .math::after {

--- a/revenge.css
+++ b/revenge.css
@@ -239,9 +239,20 @@ embed::after, marquee::after, nobr::after, noembed::after, wbr::after {
 * Empty elements
 ----------------------------------------------------------------------
 */
-
-*:empty:not(script):not(input):not(br):not(img):not(link):not(hr):not(embed):not(area):not(command):not(col):not(param):not(source):not(track):not(wbr):not(base):not(keygen):not(span.fa)::after {
+/***
+Added not:span.fa and i.fa to exclude icons hooks.
+***/
+*:empty:not(script):not(input):not(br):not(img):not(link):not(hr):not(embed):not(area):not(command):not(col):not(param):not(source):not(track):not(wbr):not(base):not(keygen):not(span.fa):not(i.fa)::after {
 	content: 'This element is empty. Why?' !important;
+}
+/**
+Icons used for pure decoration or visual styling
+
+If you're using an icon to add some extra decoration or branding, it does not need to be announced to users as they are navigating your site or app aurally. Additionally, if you're using an icon to visually re-emphasize or add styling to content already present in your HTML, it does not need to be repeated to an assistive technology-using user. You can make sure this is not read by adding the aria-hidden="true" to your Font Awesome markup.
+http://fontawesome.io/accessibility/
+****************/
+.fa:not([aria-hidden="true"])::after {
+    content: 'Use aria-hidden="true on icons.' !important;
 }
 
 /**
@@ -261,26 +272,18 @@ aside > section:first-child::after {
 	content: 'Sectioning elems are not arbitrary wrappers. Use <div>s here.' !important;
 }
 
-/*
-body > header:not([role="banner"])::after, body > div > header:not([role="banner"])::after {
-	content: 'Use role="banner" on this header element.' !important;
-}
-*/
-/*
-body > footer:not([role="contentinfo"])::after, body > div > footer:not([role="contentinfo"])::after {
-	content: 'Use role="contentinfo" on this footer element.' !important;
-}
-*/
+
 /****
-Removed as <footer> conveys contentInfo natively and updated if using non native footer element using either class footer or id footer add role contentInfo. Same for header
+Removed as <footer> requires role=contentInfo and <header> requires role=banner as these are already conveyed natively. W3C validator generates a warning if used.
 ****/
+/*
 body > div#footer:not([role="contentinfo"])::after, body > div.footer:not([role="contentinfo"])::after {
 	content: 'Use role="contentinfo" on this footer element or use native HTML5 <footer>.' !important;
 }
 body > div#header:not([role="banner"])::after, body > div.header:not([role="banner"])::after, body > div.banner:not([role="banner"])::after, body > div#banner:not([role="banner"])::after {
 	content: 'Use role="banner" on this header element or use native <header>.' !important;
 }
-
+*/
 section [role="banner"]::after, section [role="contentinfo"]::after, 
 article [role="banner"]::after, article [role="contentinfo"]::after, 
 aside [role="banner"]::after, aside [role="contentinfo"]::after {

--- a/revenge.css
+++ b/revenge.css
@@ -277,7 +277,7 @@ Removed as <footer> conveys contentInfo natively and updated if using non native
 body > footer#footer:not([role="contentinfo"])::after, body > div > footer.footer:not([role="contentinfo"])::after {
 	content: 'Use role="contentinfo" on this footer element or use native HTML5 <footer>.' !important;
 }
-body > div#header:not([role="banner"])::after, body > div.header:not([role="banner"])::after, body > div.banner:not([role="banner"])::after, body > div#banner:not([role="banner"])::after {
+body > header#header:not([role="banner"])::after, body > header.header:not([role="banner"])::after, body > div.banner:not([role="banner"])::after, body > div#banner:not([role="banner"])::after {
 	content: 'Use role="banner" on this header element or use native <header>.' !important;
 }
 

--- a/revenge.css
+++ b/revenge.css
@@ -231,7 +231,7 @@ button.disabled:not([disabled]):not([readonly])::after {
 acronym::after, applet::after, basefont::after, big::after, center::after, dir::after, 
 font::after, frame::after, frameset::after, isindex::after, listing::after, menu::after, multicol::after, 
 plaintext::after, strike::after, u::after, xmp::after, bgsound::after, blink::after, comment::after, 
-embed::after, marquee::after, nobr::after, noembed::after, wbr::after, :not(.MathJax)::after {
+embed::after, marquee::after, nobr::after, noembed::after, wbr::after, :not(span.MathJax .math)::after {
 	content: 'This element is deprecated, non-standard or obsolete.' !important;
 }
 span.MathJax .math::after {

--- a/revenge.css
+++ b/revenge.css
@@ -251,7 +251,7 @@ Icons used for pure decoration or visual styling
 If you're using an icon to add some extra decoration or branding, it does not need to be announced to users as they are navigating your site or app aurally. Additionally, if you're using an icon to visually re-emphasize or add styling to content already present in your HTML, it does not need to be repeated to an assistive technology-using user. You can make sure this is not read by adding the aria-hidden="true" to your Font Awesome markup.
 http://fontawesome.io/accessibility/
 ****************/
-:not(.fa *[aria-hidden="true"])::after {
+.fa:not([aria-hidden="true"])::after {
     content: 'Use aria-hidden="true on icons.' !important;
 }
 

--- a/revenge.css
+++ b/revenge.css
@@ -231,7 +231,7 @@ button.disabled:not([disabled]):not([readonly])::after {
 acronym::after, applet::after, basefont::after, big::after, center::after, dir::after, 
 font::after, frame::after, frameset::after, isindex::after, listing::after, menu::after, multicol::after, 
 plaintext::after, strike::after, u::after, xmp::after, bgsound::after, blink::after, comment::after, 
-embed::after, marquee::after, nobr::after, noembed::after, wbr::after, .MathJax::after {
+embed::after, marquee::after, nobr::after, noembed::after, wbr::after, :not.MathJax::after {
 	content: 'This element is deprecated, non-standard or obsolete.' !important;
 }
 span.MathJax .math::after {

--- a/revenge.css
+++ b/revenge.css
@@ -141,7 +141,8 @@ li.disabled > button:not([disabled])::after,
 a.disabled[href]:not([tabindex="-1"])::after,
 button.disabled:not([disabled])::after, 
 [data-toggle="dropdown"]:not([aria-haspopup])::after,
-span.MathJax .math::after
+span.MathJax .math::after,
+.sr-only:after
 {
    display: inline-block !important;
    background: #dc143c !important;
@@ -408,4 +409,8 @@ button.disabled:not([disabled])::after {
 
 [data-toggle="dropdown"]:not([aria-haspopup])::after {
 	content: 'Indicate the hidden menu with aria-haspopup' !important;
+}
+
+.sr-only:after{
+   content: 'Off-screen text for screen reader users. Is this text necessary?' !important; 
 }

--- a/revenge.css
+++ b/revenge.css
@@ -274,10 +274,10 @@ body > footer:not([role="contentinfo"])::after, body > div > footer:not([role="c
 /****
 Removed as <footer> conveys contentInfo natively and updated if using non native footer element using either class footer or id footer add role contentInfo. Same for header
 ****/
-body > footer#footer:not([role="contentinfo"])::after, body > div > footer.footer:not([role="contentinfo"])::after {
+body > div#footer:not([role="contentinfo"])::after, body > div.footer:not([role="contentinfo"])::after {
 	content: 'Use role="contentinfo" on this footer element or use native HTML5 <footer>.' !important;
 }
-body > header#header:not([role="banner"])::after, body > header.header:not([role="banner"])::after, body > div.banner:not([role="banner"])::after, body > div#banner:not([role="banner"])::after {
+body > div#header:not([role="banner"])::after, body > div.header:not([role="banner"])::after, body > div.banner:not([role="banner"])::after, body > div#banner:not([role="banner"])::after {
 	content: 'Use role="banner" on this header element or use native <header>.' !important;
 }
 

--- a/revenge.css
+++ b/revenge.css
@@ -251,7 +251,7 @@ Icons used for pure decoration or visual styling
 If you're using an icon to add some extra decoration or branding, it does not need to be announced to users as they are navigating your site or app aurally. Additionally, if you're using an icon to visually re-emphasize or add styling to content already present in your HTML, it does not need to be repeated to an assistive technology-using user. You can make sure this is not read by adding the aria-hidden="true" to your Font Awesome markup.
 http://fontawesome.io/accessibility/
 ****************/
-:not(i.fa[aria-hidden="true"])::after, :not(span.fa[aria-hidden="true"])::after {
+i.fa:not([aria-hidden="true"])::after, span.fa:not([aria-hidden="true"])::after {
     content: 'Use aria-hidden="true on icons.' !important;
 }
 
@@ -284,6 +284,15 @@ body > div#header:not([role="banner"])::after, body > div.header:not([role="bann
 	content: 'Use role="banner" on this header element or use native <header>.' !important;
 }
 */
+
+/***
+if div has class or ID of header. Considering if .banner #banner should be included
+*/
+div#header:not([role="banner"])::after, div.header:not([role="banner"])::after {
+	content: 'Use role="banner" on this header element or use native <header>.' !important;
+}
+
+
 section [role="banner"]::after, section [role="contentinfo"]::after, 
 article [role="banner"]::after, article [role="contentinfo"]::after, 
 aside [role="banner"]::after, aside [role="contentinfo"]::after {

--- a/revenge.css
+++ b/revenge.css
@@ -231,7 +231,7 @@ button.disabled:not([disabled]):not([readonly])::after {
 acronym::after, applet::after, basefont::after, big::after, center::after, dir::after, 
 font::after, frame::after, frameset::after, isindex::after, listing::after, menu::after, multicol::after, 
 plaintext::after, strike::after, u::after, xmp::after, bgsound::after, blink::after, comment::after, 
-embed::after, marquee::after, nobr::after, noembed::after, wbr::after, :not.MathJax::after {
+embed::after, marquee::after, nobr::after, noembed::after, wbr::after, :not(.MathJax)::after {
 	content: 'This element is deprecated, non-standard or obsolete.' !important;
 }
 span.MathJax .math::after {


### PR DESCRIPTION
Added or removed the following:

Added:
not:span.fa and i.fa to exclude Font Awesomeicons hooks on empty elements.

Added:
 i.fa:not([aria-hidden="true"])::after, span.fa:not([aria-hidden="true"])::after {
content: 'Use aria-hidden="true on icons.' !important;
} to make sure aria-hidden is included on icons

Added: if div has class or ID of header but is not a native element include role.

div#header:not([role="banner"])::after, div.header:not([role="banner"])::after {
content: 'Use role="banner" on this header element or use native

.' !important;
}

Removed Section:
requires role=contentInfo and requires role=banner as these are already conveyed natively. W3C validator generates a warning if used.

